### PR TITLE
Update Redeemable information to match the ticker rename

### DIFF
--- a/tokens/cd5b9dd91319edbb19477ad00cbef673a221e70a17ef043951fc6786.Redeemable.json
+++ b/tokens/cd5b9dd91319edbb19477ad00cbef673a221e70a17ef043951fc6786.Redeemable.json
@@ -1,9 +1,9 @@
 {
   "policyId": "cd5b9dd91319edbb19477ad00cbef673a221e70a17ef043951fc6786",
-  "name": "Redeemable",
-  "symbol": "RED",
+  "name": "Redeemable USD",
+  "symbol": "RUSD",
   "website": "https://www.shareslake.com/",
-  "description": "A fiat backed stablecoin pegged to living costs to preserve purchasing power. Shareslake base coin.",
+  "description": "The fiat-backed stablecoin issued by Shareslake. Powering the fully stable branch of Cardano.",
   "amounts": [10000, 50000, 100000, 150000, 300000, 400000, 500000, 600000, 700000, 800000, 900000, 1000000, 2000000, 3000000, 4000000, 5000000, 10000000],
   "decimalPlaces": 4
 }


### PR DESCRIPTION
Signed-off-by: Miguel Angel Cabrera Minagorri <devgorri@gmail.com>

This PR adapts the Redeemable (RED) name to Redeemable USD (RUSD) as part of a small re-branding to make it easier to identify.